### PR TITLE
[Tweak] Unshaded icon statuses

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -110,6 +110,8 @@ namespace Content.Client.Overlays;
 /// </summary>
 public sealed class EntityHealthBarOverlay : Overlay
 {
+    private static readonly ProtoId<ShaderPrototype> UnshadedShader = "unshaded";
+
     private readonly IEntityManager _entManager;
     private readonly IPrototypeManager _prototype;
 
@@ -120,6 +122,7 @@ public sealed class EntityHealthBarOverlay : Overlay
     private readonly SpriteSystem _spriteSystem;
     private readonly ProgressColorSystem _progressColor;
 
+    private readonly ShaderInstance _unshadedShader;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
     public HashSet<string> DamageContainers = new();
@@ -135,6 +138,7 @@ public sealed class EntityHealthBarOverlay : Overlay
         _statusIconSystem = _entManager.System<StatusIconSystem>();
         _spriteSystem = _entManager.System<SpriteSystem>();
         _progressColor = _entManager.System<ProgressColorSystem>();
+        _unshadedShader = _prototype.Index(UnshadedShader).Instance();
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -147,6 +151,8 @@ public sealed class EntityHealthBarOverlay : Overlay
         var scaleMatrix = Matrix3Helpers.CreateScale(new Vector2(scale, scale));
         var rotationMatrix = Matrix3Helpers.CreateRotation(-rotation);
         _prototype.TryIndex(StatusIcon, out var statusIcon);
+
+        handle.UseShader(_unshadedShader);
 
         var query = _entManager.AllEntityQueryEnumerator<MobThresholdsComponent, MobStateComponent, DamageableComponent, SpriteComponent>();
         while (query.MoveNext(out var uid,
@@ -210,6 +216,7 @@ public sealed class EntityHealthBarOverlay : Overlay
             handle.DrawRect(pixelDarken, Black.WithAlpha(128));
         }
 
+        handle.UseShader(null);
         handle.SetTransform(Matrix3x2.Identity);
     }
 

--- a/Resources/Prototypes/StatusIcon/StatusEffects/health.yml
+++ b/Resources/Prototypes/StatusIcon/StatusEffects/health.yml
@@ -83,7 +83,7 @@
   abstract: true
   priority: 3
   locationPreference: Left
-  isShaded: true
+  isShaded: false
 
 - type: healthIcon
   parent: HealthIcon

--- a/Resources/Prototypes/StatusIcon/StatusEffects/satiation.yml
+++ b/Resources/Prototypes/StatusIcon/StatusEffects/satiation.yml
@@ -83,7 +83,7 @@
   abstract: true
   priority: 5
   locationPreference: Right
-  isShaded: true
+  isShaded: false
 
 - type: satiationIcon
   id: HungerIconOverfed
@@ -112,7 +112,7 @@
   abstract: true
   priority: 5
   locationPreference: Left
-  isShaded: true
+  isShaded: false
 
 - type: satiationIcon
   id: ThirstIconOverhydrated

--- a/Resources/Prototypes/StatusIcon/job.yml
+++ b/Resources/Prototypes/StatusIcon/job.yml
@@ -90,7 +90,7 @@
   abstract: true
   priority: 1
   locationPreference: Right
-  isShaded: true
+  isShaded: false
 
 - type: jobIcon
   parent: JobIcon

--- a/Resources/Prototypes/StatusIcon/security.yml
+++ b/Resources/Prototypes/StatusIcon/security.yml
@@ -85,7 +85,7 @@
   priority: 3
   offset: 1
   locationPreference: Right
-  isShaded: true
+  isShaded: false
 
 - type: securityIcon
   parent: SecurityIcon
@@ -148,7 +148,7 @@
   priority: 2
   locationPreference: Right
   layer: Mod
-  isShaded: true
+  isShaded: false
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: MindShield

--- a/Resources/Prototypes/_Goobstation/StatusIcon/security.yml
+++ b/Resources/Prototypes/_Goobstation/StatusIcon/security.yml
@@ -8,7 +8,7 @@
   priority: 2
   locationPreference: Right
   layer: Mod
-  isShaded: true
+  isShaded: false
   icon:
     sprite: /Textures/_Goobstation/Interface/Misc/security_icons.rsi
     state: MindShield-broken


### PR DESCRIPTION
- [ ] Feature
- [ ] Fix
- [X] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Port
- [ ] Translate
- [ ] Resprite

:cl: 
- tweak: Теперь некоторые иконки HUD'ов видно даже при отсутствии света, что логично+реалистично.

Те иконки, которые видно без HUD'ов, все еще неразличимы в темноте.
